### PR TITLE
[FE/FEAT] EN Level1 문제 이어 풀기 + 결과 저장 추가

### DIFF
--- a/lib/level_1/1_3/screens/level_1_1_3_main1.dart
+++ b/lib/level_1/1_3/screens/level_1_1_3_main1.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nansan_flutter/modules/level_api/models/submit_request.dart';
 import 'package:nansan_flutter/modules/level_api/services/problem_api_service.dart';
 import 'package:nansan_flutter/level_1/shared/widgets/question_box.dart';
@@ -18,15 +19,17 @@ import 'package:nansan_flutter/shared/widgets/new_question_text.dart';
 import 'package:nansan_flutter/shared/widgets/successful_popup.dart';
 import 'package:screenshot/screenshot.dart';
 
-class LevelOneOneThreeMain1 extends StatefulWidget {
+import '../../../shared/provider/EnRiverPodProvider.dart';
+
+class LevelOneOneThreeMain1 extends ConsumerStatefulWidget {
   final String problemCode;
   const LevelOneOneThreeMain1({super.key, required this.problemCode});
 
   @override
-  State<LevelOneOneThreeMain1> createState() => _LevelOneOneThreeMain1State();
+  ConsumerState<LevelOneOneThreeMain1> createState() => _LevelOneOneThreeMain1State();
 }
 
-class _LevelOneOneThreeMain1State extends State<LevelOneOneThreeMain1>
+class _LevelOneOneThreeMain1State extends ConsumerState<LevelOneOneThreeMain1>
     with TickerProviderStateMixin {
   // 필수코드
   final ScreenshotController screenshotController = ScreenshotController();
@@ -93,7 +96,11 @@ class _LevelOneOneThreeMain1State extends State<LevelOneOneThreeMain1>
       final childProfileJson = await SecureStorageService.getChildProfile();
       final childProfile = jsonDecode(childProfileJson!);
       childId = childProfile['id'];
-      EnProblemService.saveContinueProblem(widget.problemCode, childId);
+
+      final saved = await EnProblemService.loadProblemResults(problemCode, childId);
+      ref.read(problemProgressProvider.notifier).setFromStorage(saved);
+
+      EnProblemService.saveContinueProblem(problemCode, childId);
 
       setState(() {
         // problem과 answer 데이터 저장
@@ -139,6 +146,18 @@ class _LevelOneOneThreeMain1State extends State<LevelOneOneThreeMain1>
     try {
       // API 서비스 호출
       await _apiService.submitAnswer(jsonEncode(submitRequest.toJson()));
+
+      ref.read(problemProgressProvider.notifier).record(
+        problemCode,
+        isCorrect,
+      );
+
+      await EnProblemService.saveProblemResults(
+        ref.read(problemProgressProvider),
+        problemCode,
+        childId,
+      );
+
       setState(() {
         isSubmitted = true;
       });
@@ -187,11 +206,18 @@ class _LevelOneOneThreeMain1State extends State<LevelOneOneThreeMain1>
     }
   }
 
-  void onNextPressed() {
+  void onNextPressed() async {
     final nextCode = nextProblemCode;
     if (nextCode.isEmpty) {
       debugPrint("📌 다음 문제가 없습니다.");
-      EnProblemService.clearChapterProblem(childId, widget.problemCode);
+      final progress = ref.read(problemProgressProvider);
+      await EnProblemService.saveProblemResults(
+        progress,
+        problemCode,
+        childId,
+      );
+
+      await EnProblemService.clearChapterProblem(childId, problemCode);
       Modular.to.pop();
       return;
     }

--- a/lib/level_1/1_3/screens/level_1_1_3_main3.dart
+++ b/lib/level_1/1_3/screens/level_1_1_3_main3.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nansan_flutter/modules/level_api/models/submit_request.dart';
 import 'package:nansan_flutter/modules/level_api/services/problem_api_service.dart';
 import 'package:nansan_flutter/level_1/shared/widgets/question_box.dart';
@@ -18,15 +19,17 @@ import 'package:nansan_flutter/shared/widgets/new_question_text.dart';
 import 'package:nansan_flutter/shared/widgets/successful_popup.dart';
 import 'package:screenshot/screenshot.dart';
 
-class LevelOneOneThreeMain3 extends StatefulWidget {
+import '../../../shared/provider/EnRiverPodProvider.dart';
+
+class LevelOneOneThreeMain3 extends ConsumerStatefulWidget {
   final String problemCode;
   const LevelOneOneThreeMain3({super.key, required this.problemCode});
 
   @override
-  State<LevelOneOneThreeMain3> createState() => _LevelOneOneThreeMain3State();
+  ConsumerState<LevelOneOneThreeMain3> createState() => _LevelOneOneThreeMain3State();
 }
 
-class _LevelOneOneThreeMain3State extends State<LevelOneOneThreeMain3>
+class _LevelOneOneThreeMain3State extends ConsumerState<LevelOneOneThreeMain3>
     with TickerProviderStateMixin {
   // 필수코드
   final ScreenshotController screenshotController = ScreenshotController();
@@ -93,7 +96,11 @@ class _LevelOneOneThreeMain3State extends State<LevelOneOneThreeMain3>
       final childProfileJson = await SecureStorageService.getChildProfile();
       final childProfile = jsonDecode(childProfileJson!);
       childId = childProfile['id'];
-      EnProblemService.saveContinueProblem(widget.problemCode, childId);
+
+      final saved = await EnProblemService.loadProblemResults(problemCode, childId);
+      ref.read(problemProgressProvider.notifier).setFromStorage(saved);
+
+      EnProblemService.saveContinueProblem(problemCode, childId);
 
       setState(() {
         // problem과 answer 데이터 저장
@@ -139,6 +146,18 @@ class _LevelOneOneThreeMain3State extends State<LevelOneOneThreeMain3>
     try {
       // API 서비스 호출
       await _apiService.submitAnswer(jsonEncode(submitRequest.toJson()));
+
+      ref.read(problemProgressProvider.notifier).record(
+        problemCode,
+        isCorrect,
+      );
+
+      await EnProblemService.saveProblemResults(
+        ref.read(problemProgressProvider),
+        problemCode,
+        childId,
+      );
+
       setState(() {
         isSubmitted = true;
       });
@@ -187,11 +206,18 @@ class _LevelOneOneThreeMain3State extends State<LevelOneOneThreeMain3>
     }
   }
 
-  void onNextPressed() {
+  void onNextPressed() async {
     final nextCode = nextProblemCode;
     if (nextCode.isEmpty) {
       debugPrint("📌 다음 문제가 없습니다.");
-      EnProblemService.clearChapterProblem(childId, widget.problemCode);
+      final progress = ref.read(problemProgressProvider);
+      await EnProblemService.saveProblemResults(
+        progress,
+        problemCode,
+        childId,
+      );
+
+      await EnProblemService.clearChapterProblem(childId, problemCode);
       Modular.to.pop();
       return;
     }

--- a/lib/level_1/1_3/screens/level_1_1_3_think.dart
+++ b/lib/level_1/1_3/screens/level_1_1_3_think.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nansan_flutter/level_1/1_3/widgets/Example_widget_113.dart';
 import 'package:nansan_flutter/level_1/1_3/widgets/clickable_widget_113.dart';
 import 'package:nansan_flutter/modules/level_api/models/submit_request.dart';
@@ -19,16 +20,18 @@ import 'package:nansan_flutter/shared/widgets/new_question_text.dart';
 import 'package:nansan_flutter/shared/widgets/successful_popup.dart';
 import 'package:screenshot/screenshot.dart';
 
-class LevelOneOneThreeThink extends StatefulWidget {
+import '../../../shared/provider/EnRiverPodProvider.dart';
+
+class LevelOneOneThreeThink extends ConsumerStatefulWidget {
   final String problemCode;
 
   const LevelOneOneThreeThink({super.key, required this.problemCode});
 
   @override
-  State createState() => _LevelOneOneThreeThinkState();
+  ConsumerState createState() => _LevelOneOneThreeThinkState();
 }
 
-class _LevelOneOneThreeThinkState extends State<LevelOneOneThreeThink>
+class _LevelOneOneThreeThinkState extends ConsumerState<LevelOneOneThreeThink>
     with TickerProviderStateMixin {
   // 필수코드
   final ScreenshotController screenshotController = ScreenshotController();
@@ -89,10 +92,15 @@ class _LevelOneOneThreeThinkState extends State<LevelOneOneThreeThink>
   Future _loadQuestionData() async {
     try {
       final response = await _apiService.loadProblemData(problemCode);
+
       final childProfileJson = await SecureStorageService.getChildProfile();
       final childProfile = jsonDecode(childProfileJson!);
       childId = childProfile['id'];
-      EnProblemService.saveContinueProblem(widget.problemCode, childId);
+
+      final saved = await EnProblemService.loadProblemResults(problemCode, childId);
+      ref.read(problemProgressProvider.notifier).setFromStorage(saved);
+
+      EnProblemService.saveContinueProblem(problemCode, childId);
 
       setState(() {
         nextProblemCode = response.nextProblemCode;
@@ -133,6 +141,18 @@ class _LevelOneOneThreeThinkState extends State<LevelOneOneThreeThink>
     try {
       // API 서비스 호출
       await _apiService.submitAnswer(jsonEncode(submitRequest.toJson()));
+
+      ref.read(problemProgressProvider.notifier).record(
+        problemCode,
+        isCorrect,
+      );
+
+      await EnProblemService.saveProblemResults(
+        ref.read(problemProgressProvider),
+        problemCode,
+        childId,
+      );
+
       setState(() {
         isSubmitted = true;
       });
@@ -184,11 +204,18 @@ class _LevelOneOneThreeThinkState extends State<LevelOneOneThreeThink>
     }
   }
 
-  void onNextPressed() {
+  void onNextPressed() async {
     final nextCode = nextProblemCode;
     if (nextCode.isEmpty) {
       debugPrint("📌 다음 문제가 없습니다.");
-      EnProblemService.clearChapterProblem(childId, widget.problemCode);
+      final progress = ref.read(problemProgressProvider);
+      await EnProblemService.saveProblemResults(
+        progress,
+        problemCode,
+        childId,
+      );
+
+      await EnProblemService.clearChapterProblem(childId, problemCode);
       Modular.to.pop();
       return;
     }

--- a/lib/level_1/1_4/screens/level_1_1_4_think2.dart
+++ b/lib/level_1/1_4/screens/level_1_1_4_think2.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nansan_flutter/modules/level_api/models/submit_request.dart';
 import 'package:nansan_flutter/modules/level_api/services/problem_api_service.dart';
 import 'package:nansan_flutter/level_1/shared/widgets/question_box.dart';
@@ -18,15 +19,17 @@ import 'package:nansan_flutter/shared/widgets/new_question_text.dart';
 import 'package:nansan_flutter/shared/widgets/successful_popup.dart';
 import 'package:screenshot/screenshot.dart';
 
-class LevelOneOneFourThink2 extends StatefulWidget {
+import '../../../shared/provider/EnRiverPodProvider.dart';
+
+class LevelOneOneFourThink2 extends ConsumerStatefulWidget {
   final String problemCode;
   const LevelOneOneFourThink2({super.key, required this.problemCode});
 
   @override
-  State<LevelOneOneFourThink2> createState() => _LevelOneOneFourThink2State();
+  ConsumerState<LevelOneOneFourThink2> createState() => _LevelOneOneFourThink2State();
 }
 
-class _LevelOneOneFourThink2State extends State<LevelOneOneFourThink2>
+class _LevelOneOneFourThink2State extends ConsumerState<LevelOneOneFourThink2>
     with TickerProviderStateMixin {
   // 필수코드
   final ScreenshotController screenshotController = ScreenshotController();
@@ -93,7 +96,11 @@ class _LevelOneOneFourThink2State extends State<LevelOneOneFourThink2>
       final childProfileJson = await SecureStorageService.getChildProfile();
       final childProfile = jsonDecode(childProfileJson!);
       childId = childProfile['id'];
-      EnProblemService.saveContinueProblem(widget.problemCode, childId);
+
+      final saved = await EnProblemService.loadProblemResults(problemCode, childId);
+      ref.read(problemProgressProvider.notifier).setFromStorage(saved);
+
+      EnProblemService.saveContinueProblem(problemCode, childId);
 
       setState(() {
         // problem과 answer 데이터 저장
@@ -139,6 +146,18 @@ class _LevelOneOneFourThink2State extends State<LevelOneOneFourThink2>
     try {
       // API 서비스 호출
       await _apiService.submitAnswer(jsonEncode(submitRequest.toJson()));
+
+      ref.read(problemProgressProvider.notifier).record(
+        problemCode,
+        isCorrect,
+      );
+
+      await EnProblemService.saveProblemResults(
+        ref.read(problemProgressProvider),
+        problemCode,
+        childId,
+      );
+
       setState(() {
         isSubmitted = true;
       });
@@ -187,11 +206,18 @@ class _LevelOneOneFourThink2State extends State<LevelOneOneFourThink2>
     }
   }
 
-  void onNextPressed() {
+  void onNextPressed() async{
     final nextCode = nextProblemCode;
     if (nextCode.isEmpty) {
       debugPrint("📌 다음 문제가 없습니다.");
-      EnProblemService.clearChapterProblem(childId, widget.problemCode);
+      final progress = ref.read(problemProgressProvider);
+      await EnProblemService.saveProblemResults(
+        progress,
+        problemCode,
+        childId,
+      );
+
+      await EnProblemService.clearChapterProblem(childId, problemCode);
       Modular.to.pop();
       return;
     }

--- a/lib/level_1/1_4/screens/level_1_1_4_think3.dart
+++ b/lib/level_1/1_4/screens/level_1_1_4_think3.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nansan_flutter/modules/level_api/models/submit_request.dart';
 import 'package:nansan_flutter/modules/level_api/services/problem_api_service.dart';
 import 'package:nansan_flutter/level_1/shared/widgets/question_box.dart';
@@ -18,15 +19,17 @@ import 'package:nansan_flutter/shared/widgets/new_question_text.dart';
 import 'package:nansan_flutter/shared/widgets/successful_popup.dart';
 import 'package:screenshot/screenshot.dart';
 
-class LevelOneOneFourThink3 extends StatefulWidget {
+import '../../../shared/provider/EnRiverPodProvider.dart';
+
+class LevelOneOneFourThink3 extends ConsumerStatefulWidget {
   final String problemCode;
   const LevelOneOneFourThink3({super.key, required this.problemCode});
 
   @override
-  State<LevelOneOneFourThink3> createState() => _LevelOneOneFourThink3State();
+  ConsumerState<LevelOneOneFourThink3> createState() => _LevelOneOneFourThink3State();
 }
 
-class _LevelOneOneFourThink3State extends State<LevelOneOneFourThink3>
+class _LevelOneOneFourThink3State extends ConsumerState<LevelOneOneFourThink3>
     with TickerProviderStateMixin {
   // 필수코드
   final ScreenshotController screenshotController = ScreenshotController();
@@ -93,7 +96,11 @@ class _LevelOneOneFourThink3State extends State<LevelOneOneFourThink3>
       final childProfileJson = await SecureStorageService.getChildProfile();
       final childProfile = jsonDecode(childProfileJson!);
       childId = childProfile['id'];
-      EnProblemService.saveContinueProblem(widget.problemCode, childId);
+
+      final saved = await EnProblemService.loadProblemResults(problemCode, childId);
+      ref.read(problemProgressProvider.notifier).setFromStorage(saved);
+
+      await EnProblemService.saveContinueProblem(problemCode, childId);
 
       setState(() {
         // problem과 answer 데이터 저장
@@ -139,6 +146,18 @@ class _LevelOneOneFourThink3State extends State<LevelOneOneFourThink3>
     try {
       // API 서비스 호출
       await _apiService.submitAnswer(jsonEncode(submitRequest.toJson()));
+
+      ref.read(problemProgressProvider.notifier).record(
+        problemCode,
+        isCorrect,
+      );
+
+      await EnProblemService.saveProblemResults(
+        ref.read(problemProgressProvider),
+        problemCode,
+        childId,
+      );
+
       setState(() {
         isSubmitted = true;
       });
@@ -187,11 +206,18 @@ class _LevelOneOneFourThink3State extends State<LevelOneOneFourThink3>
     }
   }
 
-  void onNextPressed() {
+  void onNextPressed() async {
     final nextCode = nextProblemCode;
     if (nextCode.isEmpty) {
       debugPrint("📌 다음 문제가 없습니다.");
-      EnProblemService.clearChapterProblem(childId, widget.problemCode);
+      final progress = ref.read(problemProgressProvider);
+      await EnProblemService.saveProblemResults(
+        progress,
+        problemCode,
+        childId,
+      );
+
+      await EnProblemService.clearChapterProblem(childId, problemCode);
       Modular.to.pop();
       return;
     }

--- a/lib/level_1/3-2/screens/level_1_3_2_basic.dart
+++ b/lib/level_1/3-2/screens/level_1_3_2_basic.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nansan_flutter/shared/widgets/new_header_widget.dart';
 import 'package:nansan_flutter/shared/widgets/new_question_text.dart';
 import 'package:screenshot/screenshot.dart';
 import '../../../modules/level_api/services/problem_api_service.dart';
+import '../../../shared/provider/EnRiverPodProvider.dart';
+import '../../../shared/services/en_problem_service.dart';
 import '../../../shared/services/image_service.dart';
 import '../../../shared/widgets/appbar_widget.dart';
 import '../../../shared/widgets/button_widget.dart';
@@ -13,16 +16,16 @@ import '../../../shared/widgets/toase_message.dart';
 import '../controller/level_1_3_2_basic_controller.dart';
 import '../widgets/basic_sample_popup.dart';
 
-class LevelOneThreeTwoBasic extends StatefulWidget {
+class LevelOneThreeTwoBasic extends ConsumerStatefulWidget {
   final String problemCode;
 
   const LevelOneThreeTwoBasic({super.key, required this.problemCode});
 
   @override
-  State<LevelOneThreeTwoBasic> createState() => _LevelOneThreeTwoBasicState();
+  ConsumerState<LevelOneThreeTwoBasic> createState() => _LevelOneThreeTwoBasicState();
 }
 
-class _LevelOneThreeTwoBasicState extends State<LevelOneThreeTwoBasic>
+class _LevelOneThreeTwoBasicState extends ConsumerState<LevelOneThreeTwoBasic>
     with TickerProviderStateMixin {
   late final LevelOneThreeTwoBasicController controller;
   final ScreenshotController screenshotController = ScreenshotController();
@@ -36,6 +39,7 @@ class _LevelOneThreeTwoBasicState extends State<LevelOneThreeTwoBasic>
     controller = LevelOneThreeTwoBasicController(
       ticker: this,
       onUpdate: () => setState(() {}),
+      ref: ref,
     );
     controller.init(widget.problemCode);
   }
@@ -103,6 +107,17 @@ class _LevelOneThreeTwoBasicState extends State<LevelOneThreeTwoBasic>
         );
 
         await ProblemApiService().submitAnswer(result);
+
+        ref.read(problemProgressProvider.notifier).record(
+          controller.problemCode,
+          controller.showCorrect,
+        );
+
+        await EnProblemService.saveProblemResults(
+          ref.read(problemProgressProvider),
+          controller.problemCode,
+          controller.childId,
+        );
 
         setState(() {
           isSubmitted = true;

--- a/lib/level_1/3-2/screens/level_1_3_2_main.dart
+++ b/lib/level_1/3-2/screens/level_1_3_2_main.dart
@@ -1,9 +1,12 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:screenshot/screenshot.dart';
 import '../../../modules/level_api/services/problem_api_service.dart';
 import '../../../shared/digit_recognition/widgets/handwriting_recognition_zone.dart';
+import '../../../shared/provider/EnRiverPodProvider.dart';
+import '../../../shared/services/en_problem_service.dart';
 import '../../../shared/services/image_service.dart';
 import '../../../shared/services/secure_storage_service.dart';
 import '../../../shared/widgets/appbar_widget.dart';
@@ -17,16 +20,16 @@ import '../../../shared/widgets/toase_message.dart';
 import '../controller/level_1_3_2_main_controller.dart';
 import '../widgets/main_sample_popup.dart';
 
-class LevelOneThreeTwoMain extends StatefulWidget {
+class LevelOneThreeTwoMain extends ConsumerStatefulWidget {
   final String problemCode;
 
   const LevelOneThreeTwoMain({super.key, required this.problemCode});
 
   @override
-  State<LevelOneThreeTwoMain> createState() => _LevelOneThreeTwoMainState();
+  ConsumerState<LevelOneThreeTwoMain> createState() => _LevelOneThreeTwoMainState();
 }
 
-class _LevelOneThreeTwoMainState extends State<LevelOneThreeTwoMain>
+class _LevelOneThreeTwoMainState extends ConsumerState<LevelOneThreeTwoMain>
     with TickerProviderStateMixin {
   late final LevelOneThreeTwoMainController controller;
   final ScreenshotController screenshotController = ScreenshotController();
@@ -41,6 +44,7 @@ class _LevelOneThreeTwoMainState extends State<LevelOneThreeTwoMain>
     controller = LevelOneThreeTwoMainController(
       ticker: this,
       onUpdate: () => setState(() {}),
+      ref: ref,
     );
     controller.init(widget.problemCode);
   }
@@ -135,6 +139,17 @@ class _LevelOneThreeTwoMainState extends State<LevelOneThreeTwoMain>
         );
 
         await ProblemApiService().submitAnswer(result);
+
+        ref.read(problemProgressProvider.notifier).record(
+          controller.problemCode,
+          controller.isCorrect,
+        );
+
+        await EnProblemService.saveProblemResults(
+          ref.read(problemProgressProvider),
+          controller.problemCode,
+          controller.childId,
+        );
 
         setState(() {
           isSubmitted = true;

--- a/lib/level_1/3_1/level_1_3_1_basic1.dart
+++ b/lib/level_1/3_1/level_1_3_1_basic1.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nansan_flutter/level_1/2_3/widgets/apple_container.dart';
 import 'package:nansan_flutter/modules/level_api/models/submit_request.dart';
 import 'package:nansan_flutter/modules/level_api/services/problem_api_service.dart';
@@ -21,15 +22,15 @@ import 'package:collection/collection.dart';
 
 import '../../shared/digit_recognition/widgets/handwriting_recognition_zone.dart';
 
-class LevelOneThreeOneBasic1 extends StatefulWidget {
+class LevelOneThreeOneBasic1 extends ConsumerStatefulWidget {
   final String problemCode;
   const LevelOneThreeOneBasic1({super.key, required this.problemCode});
 
   @override
-  State<LevelOneThreeOneBasic1> createState() => LevelOneThreeOneBasic1State();
+  ConsumerState<LevelOneThreeOneBasic1> createState() => LevelOneThreeOneBasic1State();
 }
 
-class LevelOneThreeOneBasic1State extends State<LevelOneThreeOneBasic1> with TickerProviderStateMixin {
+class LevelOneThreeOneBasic1State extends ConsumerState<LevelOneThreeOneBasic1> with TickerProviderStateMixin {
   final ScreenshotController screenshotController = ScreenshotController();
   final TimerController _timerController = TimerController();
   final ProblemApiService _apiService = ProblemApiService();

--- a/lib/level_1/4-2/controller/level_1_4_2_main_controller.dart
+++ b/lib/level_1/4-2/controller/level_1_4_2_main_controller.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../shared/digit_recognition/widgets/handwriting_recognition_zone.dart';
+import '../../../shared/provider/EnRiverPodProvider.dart';
 import '../../../shared/services/en_problem_service.dart';
 import '../../../shared/services/request_service.dart';
 import '../../../shared/services/secure_storage_service.dart';
@@ -8,8 +10,9 @@ import '../../../shared/services/secure_storage_service.dart';
 class LevelOneFourTwoMainController {
   final TickerProvider ticker;
   final VoidCallback onUpdate;
+  final WidgetRef ref;
 
-  LevelOneFourTwoMainController({required this.ticker, required this.onUpdate});
+  LevelOneFourTwoMainController({required this.ticker, required this.onUpdate, required this.ref,});
 
   late DateTime _startTime;
   late String problemCode;
@@ -35,6 +38,14 @@ class LevelOneFourTwoMainController {
   Future<void> init(String problemCode) async {
     this.problemCode = problemCode;
     childId = (await SecureStorageService.getChildId())!;
+
+
+    final saved = await EnProblemService.loadProblemResults(problemCode, childId);
+    ref.read(problemProgressProvider.notifier).setFromStorage(saved);
+
+    final progress = ref.read(problemProgressProvider);
+    debugPrint("📦 불러온 문제 기록: $progress");
+
     EnProblemService.saveContinueProblem(problemCode, childId);
 
     final response = await RequestService.post(
@@ -181,11 +192,20 @@ class LevelOneFourTwoMainController {
     };
   }
 
-  void onNextPressed() {
+  void onNextPressed() async {
     final nextCode = originalProblem["next_problem_code"] as String?;
     if (nextCode == null || nextCode.isEmpty) {
       debugPrint("📌 다음 문제가 없습니다.");
-      EnProblemService.clearChapterProblem(childId, problemCode);
+      // 최종 결과 저장 (SharedPreferences에 누적 기록 저장)
+      final progress = ref.read(problemProgressProvider);
+      await EnProblemService.saveProblemResults(
+        progress,
+        problemCode,
+        childId,
+      );
+
+      // 이어풀기 데이터 제거
+      await EnProblemService.clearChapterProblem(childId, problemCode);
       Modular.to.pop();
       return;
     }

--- a/lib/level_1/4-2/screens/level_1_4_2_main.dart
+++ b/lib/level_1/4-2/screens/level_1_4_2_main.dart
@@ -2,9 +2,12 @@ import 'dart:convert';
 import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nansan_flutter/modules/level_api/services/problem_api_service.dart';
 import 'package:screenshot/screenshot.dart';
 import '../../../shared/digit_recognition/widgets/handwriting_recognition_zone.dart';
+import '../../../shared/provider/EnRiverPodProvider.dart';
+import '../../../shared/services/en_problem_service.dart';
 import '../../../shared/services/image_service.dart';
 import '../../../shared/services/secure_storage_service.dart';
 import '../../../shared/widgets/appbar_widget.dart';
@@ -18,16 +21,16 @@ import '../../../shared/widgets/toase_message.dart';
 import '../controller/level_1_4_2_main_controller.dart';
 import '../widgets/main_sample_popup.dart';
 
-class LevelOneFourTwoMain extends StatefulWidget {
+class LevelOneFourTwoMain extends ConsumerStatefulWidget {
   final String problemCode;
 
   const LevelOneFourTwoMain({super.key, required this.problemCode});
 
   @override
-  State<LevelOneFourTwoMain> createState() => _LevelOneFourTwoMainState();
+  ConsumerState<LevelOneFourTwoMain> createState() => _LevelOneFourTwoMainState();
 }
 
-class _LevelOneFourTwoMainState extends State<LevelOneFourTwoMain> with TickerProviderStateMixin {
+class _LevelOneFourTwoMainState extends ConsumerState<LevelOneFourTwoMain> with TickerProviderStateMixin {
   late final LevelOneFourTwoMainController controller;
   final ScreenshotController screenshotController = ScreenshotController();
   bool isSubmitted = false;
@@ -40,6 +43,7 @@ class _LevelOneFourTwoMainState extends State<LevelOneFourTwoMain> with TickerPr
     controller = LevelOneFourTwoMainController(
       ticker: this,
       onUpdate: () => setState(() {}),
+      ref: ref,
     );
     controller.init(widget.problemCode);
   }
@@ -149,6 +153,17 @@ class _LevelOneFourTwoMainState extends State<LevelOneFourTwoMain> with TickerPr
         );
 
         await ProblemApiService().submitAnswer(result);
+
+        ref.read(problemProgressProvider.notifier).record(
+          controller.problemCode,
+          controller.showCorrect,
+        );
+
+        await EnProblemService.saveProblemResults(
+          ref.read(problemProgressProvider),
+          controller.problemCode,
+          controller.childId,
+        );
 
         setState(() {
           isSubmitted = true;

--- a/lib/level_1/en_1_module.dart
+++ b/lib/level_1/en_1_module.dart
@@ -240,13 +240,13 @@ class En1Module extends Module {
       },
     );
     // 3과 2차시 심화1
-    // r.child(
-    //   '/enlv1s3c2sh1',
-    //   child: (context) {
-    //     final nextCode = r.args.data as String;
-    //     return LevelOneThreeTwoPro1(problemCode: nextCode);
-    //   },
-    // );
+    r.child(
+      '/enlv1s3c2sh1',
+      child: (context) {
+        final nextCode = r.args.data as String;
+        return LevelOneThreeTwoPro1(problemCode: nextCode);
+      },
+    );
     // 4과 2차시 주요1
     r.child(
       '/enlv1s4c2jy1',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 
 import 'package:nansan_flutter/app_module.dart';
@@ -8,8 +9,14 @@ import 'package:nansan_flutter/modules/network_check/no_internet_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  runApp(ModularApp(module: AppModule(), child: const MyApp()));
+
+  runApp(
+    ProviderScope(
+      child: ModularApp(module: AppModule(), child: const MyApp()),
+    ),
+  );
 }
+
 
 class MyApp extends StatefulWidget {
   const MyApp({super.key});

--- a/lib/modules/auth/src/services/profile_service.dart
+++ b/lib/modules/auth/src/services/profile_service.dart
@@ -44,12 +44,12 @@ class ProfileService {
   String getRandomProfileImageUrl() {
     final random = Random();
     final randomImage = _imageList[random.nextInt(_imageList.length)];
-    return "https://s3.nansan.site/nansan/character/$randomImage";
+    return "https://minio.nansan.site/nansan/character/$randomImage";
   }
 
   String getRandomProfileImageUrlNonBg() {
     final random = Random();
     final randomImage = _nonBgImageList[random.nextInt(_nonBgImageList.length)];
-    return "https://s3.nansan.site/nansan/character/$randomImage";
+    return "https://minio.nansan.site/nansan/character/$randomImage";
   }
 }

--- a/lib/modules/drag_drop/controllers/drag_drop_controller_riverpod.dart
+++ b/lib/modules/drag_drop/controllers/drag_drop_controller_riverpod.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nansan_flutter/modules/drag_drop/models/card_data.dart';
+
+final dragDropControllerProvider =
+NotifierProvider<DragDropControllerRiverpod, DragDropState>(
+    DragDropControllerRiverpod.new);
+
+class DragDropState {
+  final List<CardData> availableCards;
+  final Map<int, CardData?> zoneCards;
+
+  const DragDropState({
+    this.availableCards = const [],
+    this.zoneCards = const {1: null, 2: null, 3: null, 4: null},
+  });
+
+  DragDropState copyWith({
+    List<CardData>? availableCards,
+    Map<int, CardData?>? zoneCards,
+  }) {
+    return DragDropState(
+      availableCards: availableCards ?? this.availableCards,
+      zoneCards: zoneCards ?? this.zoneCards,
+    );
+  }
+}
+
+class DragDropControllerRiverpod extends Notifier<DragDropState> {
+  @override
+  DragDropState build() => const DragDropState();
+
+  void initializeCards(List<CardData> cards) {
+    state = state.copyWith(availableCards: List.from(cards));
+  }
+
+  void handleCardDropped(CardData card, int zoneKey) {
+    final available = [...state.availableCards]..removeWhere((c) => c.id == card.id);
+    final zones = {...state.zoneCards};
+
+    final sourceZone = _findSourceZone(card.id);
+    final targetCard = zones[zoneKey];
+
+    if (sourceZone != null) {
+      // swap
+      final tmp = zones[sourceZone];
+      zones[sourceZone] = targetCard;
+      zones[zoneKey] = tmp;
+    } else {
+      // move from available
+      if (targetCard != null) {
+        available.add(targetCard);
+      }
+      zones[zoneKey] = card;
+    }
+
+    state = state.copyWith(
+      availableCards: available,
+      zoneCards: zones,
+    );
+  }
+
+  void handleCardRemoved(int zoneKey) {
+    final removed = state.zoneCards[zoneKey];
+    if (removed != null) {
+      final updatedAvailable = [...state.availableCards, removed];
+      final updatedZones = {...state.zoneCards}..[zoneKey] = null;
+      state = state.copyWith(
+        availableCards: updatedAvailable,
+        zoneCards: updatedZones,
+      );
+    }
+  }
+
+  void resetAll() {
+    final resetZones = <int, CardData?>{};
+    for (final key in state.zoneCards.keys) {
+      resetZones[key] = null;
+    }
+    state = state.copyWith(
+      availableCards: [],
+      zoneCards: resetZones,
+    );
+  }
+
+  void updateZoneCount(int newCount) {
+    final newZones = <int, CardData?>{};
+    for (int i = 1; i <= newCount; i++) {
+      newZones[i] = null;
+    }
+    state = state.copyWith(zoneCards: newZones);
+  }
+
+  int? _findSourceZone(String cardId) {
+    for (final entry in state.zoneCards.entries) {
+      if (entry.value?.id == cardId) return entry.key;
+    }
+    return null;
+  }
+}

--- a/lib/modules/drag_drop/widgets/draggable_card_list_riverpod.dart
+++ b/lib/modules/drag_drop/widgets/draggable_card_list_riverpod.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nansan_flutter/modules/drag_drop/controllers/drag_drop_controller_riverpod.dart';
+import 'package:nansan_flutter/modules/drag_drop/models/card_data.dart';
+import 'draggable_card.dart';
+
+class DraggableCardListRiverpod extends ConsumerStatefulWidget {
+  final List<Map<String, String>> candidates;
+  final double boxWidth;
+  final double boxHeight;
+  final double cardWidth;
+  final double cardHeight;
+  final bool showRemoveButton;
+
+  const DraggableCardListRiverpod({
+    super.key,
+    required this.candidates,
+    required this.boxWidth,
+    required this.boxHeight,
+    required this.cardWidth,
+    required this.cardHeight,
+    required this.showRemoveButton,
+  });
+
+  @override
+  ConsumerState<DraggableCardListRiverpod> createState() => _DraggableCardListState();
+}
+
+class _DraggableCardListState extends ConsumerState<DraggableCardListRiverpod> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final controller = ref.read(dragDropControllerProvider.notifier);
+      final available = ref.read(dragDropControllerProvider).availableCards;
+      if (available.isEmpty) {
+        final initialCards = widget.candidates
+            .where((c) => c['image_name'] != null && c['image_url'] != null)
+            .map((c) => CardData(
+          id: c['image_name']!,
+          imageName: c['image_name']!,
+          imageUrl: c['image_url']!,
+        ))
+            .toList();
+        controller.initializeCards(initialCards);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final availableCards = ref.watch(dragDropControllerProvider).availableCards;
+
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.black, width: 2),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      width: widget.boxWidth,
+      height: widget.boxHeight,
+      child: Scrollbar(
+        thumbVisibility: true,
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: availableCards
+                  .map((card) => DraggableCard(
+                showRemoveButton: widget.showRemoveButton,
+                cardData: card,
+                width: widget.cardWidth,
+                height: widget.cardHeight,
+              ))
+                  .toList(),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/drag_drop/widgets/empty_zone_riverpod.dart
+++ b/lib/modules/drag_drop/widgets/empty_zone_riverpod.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nansan_flutter/modules/drag_drop/controllers/drag_drop_controller_riverpod.dart';
+import 'package:nansan_flutter/modules/drag_drop/models/card_data.dart';
+import 'draggable_card.dart';
+
+class EmptyZoneRiverpod extends ConsumerWidget {
+  final int zoneKey;
+  final double width;
+  final double height;
+  final VoidCallback? onDrop;
+
+  const EmptyZoneRiverpod({
+    super.key,
+    required this.zoneKey,
+    this.width = 200,
+    this.height = 200,
+    this.onDrop,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(dragDropControllerProvider);
+    final controller = ref.read(dragDropControllerProvider.notifier);
+    final card = state.zoneCards[zoneKey];
+
+    return DragTarget<CardData>(
+      onWillAcceptWithDetails: (_) => true,
+      onAcceptWithDetails: (details) {
+        controller.handleCardDropped(details.data, zoneKey);
+        onDrop?.call();
+      },
+      builder: (context, candidateData, rejectedData) {
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 300),
+          width: width,
+          height: height,
+          decoration: BoxDecoration(
+            color: candidateData.isNotEmpty ? Colors.blue.shade100 : Colors.grey.shade200,
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(
+              color: candidateData.isNotEmpty ? Colors.blue : Colors.grey.shade400,
+              width: 2,
+            ),
+          ),
+          child: card != null
+              ? Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: DraggableCard(
+              width: 100,
+              height: 100,
+              cardData: card,
+              showRemoveButton: true,
+              onRemove: () => controller.handleCardRemoved(zoneKey),
+            ),
+          )
+              : const Center(child: Column(mainAxisSize: MainAxisSize.min, children: [])),
+        );
+      },
+    );
+  }
+}

--- a/lib/shared/model/EnProblemRecord.dart
+++ b/lib/shared/model/EnProblemRecord.dart
@@ -1,0 +1,6 @@
+class EnProblemRecord {
+  final String problemCode;
+  final bool isCorrect;
+
+  EnProblemRecord({required this.problemCode, required this.isCorrect});
+}

--- a/lib/shared/provider/EnRiverPodProvider.dart
+++ b/lib/shared/provider/EnRiverPodProvider.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final problemProgressProvider =
+StateNotifierProvider<ProblemProgressNotifier, Map<String, bool>>(
+        (ref) => ProblemProgressNotifier());
+
+class ProblemProgressNotifier extends StateNotifier<Map<String, bool>> {
+  ProblemProgressNotifier() : super({});
+
+  void record(String problemCode, bool isCorrect) {
+    state = {
+      ...state,
+      problemCode: isCorrect,
+    };
+  }
+
+  void setFromStorage(Map<String, bool> saved) {
+    state = {...saved};
+  }
+
+  void clear() {
+    state = {};
+  }
+
+  String? get lastProblemCode {
+    if (state.isEmpty) return null;
+    return state.keys.last;
+  }
+
+  int get totalCount => state.length;
+  int get correctCount =>
+      state.values.where((result) => result == true).length;
+}


### PR DESCRIPTION
EN Level1 이어풀기 기능에 결과 저장 로직을 추가하는 방향으로 구현을 진행하였습니다.
현재 라우팅이 되지 않는 일부 차시는 테스트가 필요하며, 페이지만 있고 구현이 안되어 있는 부분은 제외하였습니다.

저장 로직 먼저 구현 후, 추후 결과 보여주는 UI 추가할 예정입니다.